### PR TITLE
Expand query testing

### DIFF
--- a/main/tests/test_query.py
+++ b/main/tests/test_query.py
@@ -16,7 +16,7 @@ from main.query import (
     build_citation_for_docid,
     build_search_results,
     get_indexed_item,
-    get_indexed_ref_by_query,
+    get_indexed_ref_by_query, search_refs_relaton_struct,
 )
 from main.types import CompositeSourcedBibliographicItem, IndexedBibliographicItem
 
@@ -59,6 +59,24 @@ class QueryTestCase(TestCase):
         self.assertIsInstance(doctypes, list)
         self.assertGreater(len(doctypes), 0)
         self.assertIsInstance(doctypes[0], tuple)
+
+    def test_search_refs_relaton_struct(self):
+        limit = 1
+        objs = [{'docid': [{'id': self._get_list_of_docids_for_dataset_from_fixture()[0].get("id")}]}]
+        refs = search_refs_relaton_struct(*objs, limit=limit)
+        self.assertIsInstance(refs, QuerySet[RefData])
+        self.assertGreater(refs.count(), 0)
+        self.assertLessEqual(refs.count(), limit)
+
+    def test_search_refs_relaton_struct_empty_results(self):
+        """
+        Test that search_refs_relaton_struct returns an empty list of
+        results when called with an empty list of objs.
+        """
+        objs = []
+        refs = search_refs_relaton_struct(*objs)
+        self.assertIsInstance(refs, QuerySet[RefData])
+        self.assertEqual(refs.count(), 0)
 
     def test_search_refs_relaton_field(self):
         docids = self._get_list_of_docids_for_dataset_from_fixture("rfcs")

--- a/main/tests/test_query.py
+++ b/main/tests/test_query.py
@@ -16,7 +16,8 @@ from main.query import (
     build_citation_for_docid,
     build_search_results,
     get_indexed_item,
-    get_indexed_ref_by_query, search_refs_relaton_struct,
+    get_indexed_ref_by_query,
+    search_refs_relaton_struct,
 )
 from main.types import CompositeSourcedBibliographicItem, IndexedBibliographicItem
 
@@ -61,8 +62,36 @@ class QueryTestCase(TestCase):
         self.assertIsInstance(doctypes[0], tuple)
 
     def test_search_refs_relaton_struct(self):
-        limit = 1
-        objs = [{'docid': [{'id': self._get_list_of_docids_for_dataset_from_fixture()[0].get("id")}]}]
+        limit = 2
+        objs = [
+            {
+                "docid": [
+                    {
+                        "id": self._get_list_of_docids_for_dataset_from_fixture()[
+                            0
+                        ].get("id")
+                    }
+                ]
+            },
+            {
+                "docid": [
+                    {
+                        "id": self._get_list_of_docids_for_dataset_from_fixture("misc")[
+                            0
+                        ].get("id")
+                    }
+                ]
+            },
+            {
+                "docid": [
+                    {
+                        "id": self._get_list_of_docids_for_dataset_from_fixture("ieee")[
+                            0
+                        ].get("id")
+                    }
+                ]
+            },
+        ]
         refs = search_refs_relaton_struct(*objs, limit=limit)
         self.assertIsInstance(refs, QuerySet[RefData])
         self.assertGreater(refs.count(), 0)

--- a/main/tests/test_query.py
+++ b/main/tests/test_query.py
@@ -64,33 +64,9 @@ class QueryTestCase(TestCase):
     def test_search_refs_relaton_struct(self):
         limit = 2
         objs = [
-            {
-                "docid": [
-                    {
-                        "id": self._get_list_of_docids_for_dataset_from_fixture()[
-                            0
-                        ].get("id")
-                    }
-                ]
-            },
-            {
-                "docid": [
-                    {
-                        "id": self._get_list_of_docids_for_dataset_from_fixture("misc")[
-                            0
-                        ].get("id")
-                    }
-                ]
-            },
-            {
-                "docid": [
-                    {
-                        "id": self._get_list_of_docids_for_dataset_from_fixture("ieee")[
-                            0
-                        ].get("id")
-                    }
-                ]
-            },
+            {"docid": [{"id": self._get_list_of_docids_for_dataset_from_fixture()[0].get("id")}]},
+            {"docid": [{"id": self._get_list_of_docids_for_dataset_from_fixture("misc")[0].get("id")}]},
+            {"docid": [{"id": self._get_list_of_docids_for_dataset_from_fixture("ieee")[0].get("id")}]},
         ]
         refs = search_refs_relaton_struct(*objs, limit=limit)
         self.assertIsInstance(refs, QuerySet[RefData])


### PR DESCRIPTION
Add missing tests for function `test_search_refs_relaton_struct`.

Code coverage for query.py is now 89%