### PR TITLE
chore: remove CODECOV_TOKEN

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Build the Docker image
         run: docker compose -f docker-compose.test.yml build
       - name: Run tests
-        env:
-          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
         run: docker compose -f docker-compose.test.yml up --exit-code-from test
       - name: Dump docker logs on failure
         if: failure()

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -23,7 +23,7 @@ services:
     depends_on:
       - test-db
       - test-redis
-    command: sh -c "/wait && python -m coverage run manage.py test && ./codecov -t ${CODECOV_TOKEN}"
+    command: sh -c "/wait && python -m coverage run manage.py test && ./codecov"
     environment:
       - WAIT_HOSTS=test-db:5432
       - WAIT_HOSTS_TIMEOUT=300

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -41,4 +41,4 @@ RUN chmod +x /wait
 RUN curl -Os https://uploader.codecov.io/latest/linux/codecov
 RUN chmod +x codecov
 
-CMD python -m coverage run manage.py test && ./codecov -t ${CODECOV_TOKEN}
+CMD python -m coverage run manage.py test && ./codecov


### PR DESCRIPTION
The Codecov uploader does not require a token if the repository is public (like in this case).